### PR TITLE
Fix file-based communication path

### DIFF
--- a/PropHDG
+++ b/PropHDG
@@ -51,6 +51,9 @@ bool  bleedDone       = false;
 
 double initialBalance = 0;
 
+// shared signal file path when using FILE_BASED communication
+string SignalFilePath = "";
+
 // dashboard prefix
 string dash = "PropEA_Hedge_";
 
@@ -89,6 +92,9 @@ int OnInit()
 {
    trade.SetExpertMagicNumber(Magic_Number);
    initialBalance = AccountInfoDouble(ACCOUNT_BALANCE);
+
+   if(CommunicationMethod==FILE_BASED)
+      SignalFilePath = TerminalInfoString(TERMINAL_COMMONDATA_PATH) + "\\Synergy_Signals.txt";
 
    CreateDashboard();
 
@@ -174,10 +180,12 @@ void CheckForHedgeSignals()
    }
    else // FILE_BASED
    {
-      string file="Synergy_Signals.txt";
-      if(!FileIsExist(file)) return;
-      int h=FileOpen(file,FILE_READ|FILE_TXT); if(h==INVALID_HANDLE) return;
-      string content=FileReadString(h); FileClose(h); FileDelete(file);
+      if(SignalFilePath=="")
+         SignalFilePath = TerminalInfoString(TERMINAL_COMMONDATA_PATH) + "\\Synergy_Signals.txt";
+      if(!FileIsExist(SignalFilePath)) return;
+      int h=FileOpen(SignalFilePath,FILE_READ|FILE_TXT);
+      if(h==INVALID_HANDLE) return;
+      string content=FileReadString(h); FileClose(h); FileDelete(SignalFilePath);
       string p[]; if(StringSplit(content,',',p)<6) return;
       ProcessSignal(p[0],p[1],StringToDouble(p[2]),StringToDouble(p[3]),StringToDouble(p[4]));
    }

--- a/PropMain
+++ b/PropMain
@@ -48,6 +48,9 @@ const int    LINK_TIMEOUT_SEC = 15;         // grace window before status = NOT 
 ulong        lastPulseSent    = 0;          // when we last pinged the other side
 bool         linkWasOK        = false;      // remembers previous state for debug prints
 
+// path to the shared signal file when FILE_BASED communication is used
+string       SignalFilePath   = "";
+
 
 //--------------------------------------------------------------------
 // 2.  UTILITY — indicator buffer guard                               
@@ -364,19 +367,22 @@ int OnInit()
       }
       else
       {
+         // Prepare path in the terminal's common data folder
+         SignalFilePath = TerminalInfoString(TERMINAL_COMMONDATA_PATH) + "\\Synergy_Signals.txt";
          // Test file creation for file-based communication
-         string fileName = "Synergy_Signals.txt";
-         int fileHandle = FileOpen(fileName, FILE_WRITE|FILE_TXT);
+         int fileHandle = FileOpen(SignalFilePath, FILE_WRITE|FILE_TXT);
 
          if(fileHandle != INVALID_HANDLE)
          {
             FileWriteString(fileHandle, "INIT,"+ IntegerToString(TimeCurrent()));
             FileClose(fileHandle);
-            Print("Hedge communication enabled (File-Based). Target EA Magic: ", HedgeEA_Magic);
+            Print("Hedge communication enabled (File-Based) via ", SignalFilePath,
+                  ". Target EA Magic: ", HedgeEA_Magic);
          }
          else
          {
-            Print("Failed to initialize file-based communication. Error: ", GetLastError());
+            Print("Failed to initialize file-based communication at ", SignalFilePath,
+                  ". Error: ", GetLastError());
             return(INIT_FAILED);
          }
       }
@@ -1948,8 +1954,9 @@ void SendHedgeSignal(string signalType, string direction, double volume, double 
    else
    {
       // Use file-based communication
-      string fileName = "Synergy_Signals.txt";
-      int fileHandle = FileOpen(fileName, FILE_WRITE|FILE_TXT);
+      if(SignalFilePath=="")
+         SignalFilePath = TerminalInfoString(TERMINAL_COMMONDATA_PATH) + "\\Synergy_Signals.txt";
+      int fileHandle = FileOpen(SignalFilePath, FILE_WRITE|FILE_TXT);
       
       if(fileHandle != INVALID_HANDLE)
       {
@@ -1962,10 +1969,11 @@ void SendHedgeSignal(string signalType, string direction, double volume, double 
                              
          FileWriteString(fileHandle, signalData);
          FileClose(fileHandle);
+         Print("Signal file written to ", SignalFilePath);
       }
       else
       {
-         Print("Error opening signal file: ", GetLastError());
+         Print("Error opening signal file at ", SignalFilePath, ": ", GetLastError());
       }
    }
 }

--- a/docs/CONNECTION_FIX_NOTES.md
+++ b/docs/CONNECTION_FIX_NOTES.md
@@ -1,0 +1,18 @@
+# Fixing PropMain ↔ PropHDG connectivity
+
+The current releases of the EAs (`PropMain` and `PropHDG`) rely on **global variables** to exchange heartbeat and trading signals. Global variables are only visible inside the same MetaTrader 5 terminal. If each EA runs on a different terminal (e.g. prop account vs live account), the global-variable link never appears and the dashboard reports *NOT OK*.
+
+A simple workaround is switching to the file-based communication mode and storing the signal file inside the **common data folder** so both terminals can access it.
+
+## Steps
+1. In the EA inputs set `CommunicationMethod` to `FILE_BASED` for both EAs.
+2. Modify the source code so the signal file path uses `TerminalInfoString(TERMINAL_COMMONDATA_PATH)`:
+
+```mql5
+string commFile = TerminalInfoString(TERMINAL_COMMONDATA_PATH) + "\\Synergy_Signals.txt";
+int fileHandle = FileOpen(commFile, FILE_WRITE|FILE_TXT);
+```
+3. Recompile both EAs using the changed path.
+4. Ensure both terminals have permission to read/write the common data folder.
+
+Using the common data location lets the heartbeat file be shared across installations and the link becomes stable.


### PR DESCRIPTION
## Summary
- add `SignalFilePath` variable for shared file path
- use terminal common data folder for file-based communication
- update message logs to include full path for debugging

## Testing
- `git status --short`
