### PR TITLE
Fix hedge execution logging and improve trade lookup

### DIFF
--- a/PropHDG
+++ b/PropHDG
@@ -616,11 +616,19 @@ void ProcessSignal(string signalType,string direction,double volume,double tp,do
 
    if(signalType=="OPEN")
    {
+      bool ok=false;
       if(direction=="BUY" && volume>0)
-         trade.Buy(volume,_Symbol,0,sl,tp,"Hedge");
+         ok=trade.Buy(volume,_Symbol,0,sl,tp,"Hedge");
       else if(direction=="SELL"&& volume>0)
-         trade.Sell(volume,_Symbol,0,sl,tp,"Hedge");
-      Print("Hedge OPEN ",direction," ",DoubleToString(volume,2));
+         ok=trade.Sell(volume,_Symbol,0,sl,tp,"Hedge");
+
+      int ret=trade.ResultRetcode();
+      if(!ok)
+         Print("ERROR: Hedge OPEN failed retcode ",ret,
+               " err=",GetLastError());
+      else
+         Print("Hedge OPEN ",direction," ",DoubleToString(volume,2),
+               " ret=",ret);
    }
    else if(signalType=="MODIFY")
    {

--- a/PropMain
+++ b/PropMain
@@ -673,10 +673,19 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
    if(trans.type!=TRADE_TRANSACTION_DEAL_ADD) return;
    if(trans.symbol!=_Symbol)                  return;
 
-   // Ignore EA managed positions
-   if(trans.magic==Magic_Number) return;
+   // Pull deal info from history for reliability
+   long dealMagic = trans.deal_magic;
+   long dealEntry = trans.entry;
+   if(trans.deal>0 && HistoryDealSelect(trans.deal))
+   {
+      dealMagic = HistoryDealGetInteger(trans.deal, DEAL_MAGIC);
+      dealEntry = HistoryDealGetInteger(trans.deal, DEAL_ENTRY);
+   }
 
-   if(trans.deal_entry==DEAL_ENTRY_IN)
+   // Ignore EA managed positions
+   if(dealMagic==Magic_Number) return;
+
+   if(dealEntry==DEAL_ENTRY_IN)
    {
       bool isLong = (trans.deal_type==DEAL_TYPE_BUY);
 
@@ -686,7 +695,7 @@ void OnTradeTransaction(const MqlTradeTransaction &trans,
       SendHedgeSignal("OPEN", isLong?"SELL":"BUY", hedgeLotsLast,
                       trans.price_tp, trans.price_sl);
    }
-   else if(trans.deal_entry==DEAL_ENTRY_OUT)
+   else if(dealEntry==DEAL_ENTRY_OUT)
    {
       bool closingLong  = (trans.deal_type==DEAL_TYPE_SELL);
       double vol        = NormalizeLots(trans.volume*hedgeFactor);


### PR DESCRIPTION
## Summary
- guard manual trade info using history lookups
- log hedge trade result with error codes for troubleshooting

## Testing
- `git status --short`
