### PR TITLE
Add deinit cleanup for file-based communication

### DIFF
--- a/PropHDG
+++ b/PropHDG
@@ -350,7 +350,8 @@ void OnDeinit(const int reason)
       // Use absolute path for cleanup
       string commonPath = TerminalInfoString(TERMINAL_COMMONDATA_PATH) + "\\MQL5\\Files";
       string heartbeatFile = commonPath + "\\MT5com_hedge_heartbeat.txt";
-      
+      string signalFile    = commonPath + "\\MT5com.txt";
+
       // Check if file exists using direct path
       int fileHandle = FileOpen(heartbeatFile, FILE_READ|FILE_TXT);
       if(fileHandle != INVALID_HANDLE) {
@@ -358,7 +359,17 @@ void OnDeinit(const int reason)
          if(FileDelete(heartbeatFile)) {
             Print("Deleted hedge heartbeat file: ", heartbeatFile);
          } else {
-            Print("Failed to delete heartbeat file: ", GetLastError());
+            Print("Failed to delete hedge heartbeat file: ", GetLastError());
+         }
+      }
+
+      fileHandle = FileOpen(signalFile, FILE_READ|FILE_TXT);
+      if(fileHandle != INVALID_HANDLE) {
+         FileClose(fileHandle);
+         if(FileDelete(signalFile)) {
+            Print("Deleted signal file: ", signalFile);
+         } else {
+            Print("Failed to delete signal file: ", GetLastError());
          }
       }
    }

--- a/PropMain
+++ b/PropMain
@@ -655,8 +655,32 @@ void OnDeinit(const int reason)
       GlobalVariableDel("EASignal_Direction_"+IntegerToString(HedgeEA_Magic));
       GlobalVariableDel("EASignal_Volume_"+IntegerToString(HedgeEA_Magic));
       GlobalVariableDel("EASignal_SL_"+IntegerToString(HedgeEA_Magic));
-      GlobalVariableDel("EASignal_TP_"+IntegerToString(HedgeEA_Magic));
-      GlobalVariableDel("EASignal_Time_"+IntegerToString(HedgeEA_Magic));
+   GlobalVariableDel("EASignal_TP_"+IntegerToString(HedgeEA_Magic));
+   GlobalVariableDel("EASignal_Time_"+IntegerToString(HedgeEA_Magic));
+  }
+
+   // Remove temporary files when using file communication
+   if(EnableHedgeCommunication && CommunicationMethod == FILE_BASED)
+   {
+      string commonPath   = TerminalInfoString(TERMINAL_COMMONDATA_PATH) + "\\MQL5\\Files";
+      string heartbeatFile = commonPath + "\\MT5com_heartbeat.txt";
+      string signalFile    = commonPath + "\\MT5com.txt";
+
+      int fh = FileOpen(heartbeatFile, FILE_READ|FILE_TXT);
+      if(fh != INVALID_HANDLE)
+      {
+         FileClose(fh);
+         if(FileDelete(heartbeatFile))
+            Print("Deleted heartbeat file: ", heartbeatFile);
+      }
+
+      fh = FileOpen(signalFile, FILE_READ|FILE_TXT);
+      if(fh != INVALID_HANDLE)
+      {
+         FileClose(fh);
+         if(FileDelete(signalFile))
+            Print("Deleted signal file: ", signalFile);
+      }
    }
    
    Print("Synergy Strategy stopped. Reason: ", GetUninitReasonText(reason));


### PR DESCRIPTION
## Summary
- clean up heartbeat and signal files when PropMain or PropHDG are removed

## Testing
- `true`