### PR TITLE
Fix bar confirmation check

### DIFF
--- a/PropMain.mq5
+++ b/PropMain.mq5
@@ -2303,7 +2303,17 @@ bool IsNewBar()
 // used by IsConfirmedBar()
 bool IsConfirmedBar()
 {
-   return  ( TimeCurrent() - TimeSeries[0] ) >= PeriodSeconds();
+   // Ensure we reference the *previous* bar so it is fully closed when
+   // this function is called on the first tick of a new bar. Using index 0
+   // prevented any confirmation because TimeSeries[0] is the current bar
+   // start time. As a result the EA always detected an unconfirmed bar and
+   // skipped trading. We now check TimeSeries[1] which represents the last
+   // completed bar.
+   if(ArraySize(TimeSeries) < 2)
+      return false;
+
+   datetime prevBarTime = TimeSeries[1];
+   return (TimeCurrent() - prevBarTime) >= PeriodSeconds();
 }
 //+------------------------------------------------------------------+
 //| Check if market is open                                          |

--- a/PropMain_Dash.mq5
+++ b/PropMain_Dash.mq5
@@ -2286,7 +2286,15 @@ bool IsNewBar()
 // used by IsConfirmedBar()
 bool IsConfirmedBar()
 {
-   return  ( TimeCurrent() - TimeSeries[0] ) >= PeriodSeconds();
+   // Use the previous bar's timestamp to verify that a bar has fully
+   // completed. The earlier implementation referenced the current bar
+   // which caused `IsConfirmedBar()` to remain false at the new bar's
+   // first tick, effectively blocking entries.
+   if(ArraySize(TimeSeries) < 2)
+      return false;
+
+   datetime prevBarTime = TimeSeries[1];
+   return (TimeCurrent() - prevBarTime) >= PeriodSeconds();
 }
 //+------------------------------------------------------------------+
 //| Check if market is open                                          |


### PR DESCRIPTION
## Summary
- avoid mis-detecting unfinished bars by verifying previous bar

## Testing
- `This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.`